### PR TITLE
Use Vite for bundled plugins

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,15 @@
+/* Vendor styles */
+@import "../../public/assets/css/vendor/remixicon.css";
+@import "../../public/assets/css/vendor/aos.css";
+@import "../../public/assets/css/vendor/swiper-bundle.min.css";
+@import "../../public/assets/css/vendor/owl.carousel.min.css";
+@import "../../public/assets/css/vendor/slick.min.css";
+@import "../../public/assets/css/vendor/animate.min.css";
+@import "../../public/assets/css/vendor/jquery-range-ui.css";
+
+/* Main template style */
+@import "../../public/assets/css/style.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,13 @@
 import '../css/app.css';
+
+import '../../public/assets/js/vendor/jquery.min.js';
+import '../../public/assets/js/vendor/jquery.zoom.min.js';
+import '../../public/assets/js/vendor/aos.js';
+import '../../public/assets/js/vendor/swiper-bundle.min.js';
+import '../../public/assets/js/vendor/smoothscroll.min.js';
+import '../../public/assets/js/vendor/countdownTimer.js';
+import '../../public/assets/js/vendor/owl.carousel.min.js';
+import '../../public/assets/js/vendor/slick.min.js';
+import '../../public/assets/js/vendor/jquery-range-ui.min.js';
+
+import '../../public/assets/js/main.js';

--- a/resources/views/layouts/web/head-css.blade.php
+++ b/resources/views/layouts/web/head-css.blade.php
@@ -1,20 +1,6 @@
 <link rel="icon" href="{{ asset('assets/img/favicon/favicon.png') }}" type="image/x-icon">
 
-<!-- Css All Plugins Files -->
-
-
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/remixicon.css') }}">
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/aos.css') }}">
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/swiper-bundle.min.css') }}">
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/owl.carousel.min.css') }}">
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/slick.min.css') }}">
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/animate.min.css') }}">
-<link rel="stylesheet" href="{{ asset('assets/css/vendor/jquery-range-ui.css') }}">
+<!-- Styles compiled with Vite -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-
-<!-- tailwindcss -->
-<script src="{{ asset('assets/js/vendor/tailwindcss3.4.5.js') }}"></script>
-
-<!-- Main Style -->
-<link rel="stylesheet" href="{{ asset('assets/css/style.css') }}">
+@vite('resources/css/app.css')
 

--- a/resources/views/layouts/web/plugins.blade.php
+++ b/resources/views/layouts/web/plugins.blade.php
@@ -1,13 +1,2 @@
-   <!-- Plugins -->
-   <script src="{{ asset('assets/js/vendor/jquery.min.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/jquery.zoom.min.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/aos.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/swiper-bundle.min.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/smoothscroll.min.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/countdownTimer.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/owl.carousel.min.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/slick.min.js')}}"></script>
-   <script src="{{ asset('assets/js/vendor/jquery-range-ui.min.js')}}"></script>
-
-   <!-- main-js -->
-   <script src="{{ asset('assets/js/main.js')}}"></script>
+   <!-- Scripts compiled with Vite -->
+   @vite('resources/js/app.js')


### PR DESCRIPTION
## Summary
- include theme plugin assets directly in Vite entry files
- load CSS/JS through `@vite` directives

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889801b5ae883239267ebaa9e8c1f70